### PR TITLE
Add TransactionLike interface

### DIFF
--- a/dblike.go
+++ b/dblike.go
@@ -9,4 +9,5 @@ type DBLike interface {
 	QueryRow(string, ...interface{}) *sql.Row
 	Prepare(string) (*sql.Stmt, error)
 	Exec(string, ...interface{}) (sql.Result, error)
+	Begin() (TransactionLike, error)
 }

--- a/transaction_like.go
+++ b/transaction_like.go
@@ -1,0 +1,6 @@
+package dblib
+
+type TransactionLike interface {
+	Rollback() error
+	Commit() error
+}

--- a/util.go
+++ b/util.go
@@ -1,9 +1,5 @@
 package dblib
 
-import (
-	"database/sql"
-)
-
 func Run(tx DBLike, command string) error {
 	stmt, err := tx.Prepare(command)
 	if err != nil {
@@ -17,7 +13,7 @@ func Run(tx DBLike, command string) error {
 	return nil
 }
 
-func Transact(db *sql.DB, txFunc func(*sql.Tx) error) (err error) {
+func Transact(db DBLike, txFunc func(TransactionLike) error) (err error) {
 	tx, err := db.Begin()
 	if err != nil {
 		return


### PR DESCRIPTION
Added `Begin()` to DBLike.

The Create functions in [schema.resolvers.go](https://github.com/boourns/go-gql-typescript-example/blob/main/server/graph/schema.resolvers.go) do all the work in place while the Get functions are moved to the models themselves. This is because the models are usually passed a `DBLike` instead of a `*sql.DB`. Code that does insertion should be wrapped in a Transaction that are only available on `sql.DB`.

This PR abstracts enough of the Transaction api to allow everything to be done in the model with `Like` interfaces.